### PR TITLE
fix: Address critical bugs in product variations and admin CRUDs

### DIFF
--- a/app/Http/Controllers/ColorController.php
+++ b/app/Http/Controllers/ColorController.php
@@ -36,7 +36,7 @@ class ColorController extends Controller
             'status' => 'required|in:active,inactive',
         ]);
 
-        $data = $request->validated(); // Use validated data
+        $data = $request->only(['name', 'hex_code', 'status']);
         $status = Color::create($data);
 
         if ($status) {
@@ -75,7 +75,7 @@ class ColorController extends Controller
             'status' => 'required|in:active,inactive',
         ]);
 
-        $data = $request->validated(); // Use validated data
+        $data = $request->only(['name', 'hex_code', 'status']);
         $status = $color->fill($data)->save();
 
         if ($status) {

--- a/app/Http/Controllers/OrderController.php
+++ b/app/Http/Controllers/OrderController.php
@@ -178,7 +178,21 @@ class OrderController extends Controller
      */
     public function show($id)
     {
-        $order=Order::with('orderItems.product', 'orderItems.variant.color', 'orderItems.variant.size', 'orderItems.variant.specification', 'shipping', 'user')->find($id);
+        $order=Order::with([
+            'orderItems',
+            'orderItems.product',
+            'orderItems.variant',
+            'orderItems.variant.color',
+            'orderItems.variant.size',
+            'orderItems.variant.specification',
+            'shipping',
+            'user'
+        ])->find($id);
+
+        if (!$order) {
+            request()->session()->flash('error', __('flash_messages.order_not_found'));
+            return redirect()->route('order.index');
+        }
         return view('backend.order.show')->with('order',$order);
     }
 

--- a/app/Http/Controllers/ProductController.php
+++ b/app/Http/Controllers/ProductController.php
@@ -35,9 +35,9 @@ class ProductController extends Controller
     {
         $brands = Brand::get();
         $categories = Category::where('is_parent', 1)->get();
-        $colors = Color::where('status', 'active')->orderBy('name')->get();
-        $sizes = Size::where('status', 'active')->orderBy('name')->get();
-        $specifications = Specification::where('status', 'active')->orderBy('name')->orderBy('value')->get();
+        $colors = Color::orderBy('name')->get();
+        $sizes = Size::orderBy('name')->get();
+        $specifications = Specification::orderBy('name')->orderBy('value')->get();
 
         return view('backend.product.create')
             ->with('categories', $categories)
@@ -149,9 +149,9 @@ class ProductController extends Controller
         $product = Product::with(['variants', 'variants.color', 'variants.size', 'variants.specification'])->findOrFail($id);
         $brands = Brand::get();
         $categories = Category::where('is_parent', 1)->get();
-        $colors = Color::where('status', 'active')->orderBy('name')->get();
-        $sizes = Size::where('status', 'active')->orderBy('name')->get();
-        $specifications = Specification::where('status', 'active')->orderBy('name')->orderBy('value')->get();
+        $colors = Color::orderBy('name')->get();
+        $sizes = Size::orderBy('name')->get();
+        $specifications = Specification::orderBy('name')->orderBy('value')->get();
 
         return view('backend.product.edit')
             ->with('product', $product)

--- a/app/Http/Controllers/SizeController.php
+++ b/app/Http/Controllers/SizeController.php
@@ -35,7 +35,7 @@ class SizeController extends Controller
             'status' => 'required|in:active,inactive',
         ]);
 
-        $data = $request->validated(); // Use validated data
+        $data = $request->only(['name', 'status']);
         $status = Size::create($data);
 
         if ($status) {
@@ -72,7 +72,7 @@ class SizeController extends Controller
             'status' => 'required|in:active,inactive',
         ]);
 
-        $data = $request->validated(); // Use validated data
+        $data = $request->only(['name', 'status']);
         $status = $size->fill($data)->save();
 
         if ($status) {

--- a/app/Http/Controllers/SpecificationController.php
+++ b/app/Http/Controllers/SpecificationController.php
@@ -44,7 +44,7 @@ class SpecificationController extends Controller
             'status' => 'required|in:active,inactive',
         ]);
 
-        $data = $request->validated(); // Use validated data
+        $data = $request->only(['name', 'value', 'status']);
         $status = Specification::create($data);
 
         if ($status) {
@@ -89,7 +89,7 @@ class SpecificationController extends Controller
             'status' => 'required|in:active,inactive',
         ]);
 
-        $data = $request->validated(); // Use validated data
+        $data = $request->only(['name', 'value', 'status']);
         $status = $specification->fill($data)->save();
 
         if ($status) {

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -46,4 +46,8 @@ class Product extends Model
         return $this->hasOne(Brand::class,'id','brand_id');
     }
 
+    public function variants()
+    {
+        return $this->hasMany(\App\Models\ProductVariant::class);
+    }
 }

--- a/resources/views/backend/order/show.blade.php
+++ b/resources/views/backend/order/show.blade.php
@@ -80,7 +80,27 @@
         <tr>
           <td>{{ $loop->iteration }}</td>
           <td><img src="{{ asset($item->image) }}" alt="Product Image" style="width:50px"></td>
-          <td>{{ $item->name }}</td>
+          <td>
+            {{ $item->name }}
+            @if($item->variant)
+                <div style="font-size: 0.9em; color: #555;">
+                    <small>
+                        @if($item->variant->sku)
+                            SKU: {{ $item->variant->sku }}<br>
+                        @endif
+                        @if($item->variant->color)
+                            {{ __('cart.label_color') }}: {{ $item->variant->color->name }}<br>
+                        @endif
+                        @if($item->variant->size)
+                            {{ __('cart.label_size') }}: {{ $item->variant->size->name }}<br>
+                        @endif
+                        @if($item->variant->specification)
+                            {{ $item->variant->specification->name }}: {{ $item->variant->specification->value }}
+                        @endif
+                    </small>
+                </div>
+            @endif
+          </td>
           <td>${{ number_format($item->price, 2) }}</td>
           <td>{{ $item->size }}</td>
           <td>{{ $item->quantity }}</td>


### PR DESCRIPTION
This commit resolves several critical issues identified during testing:

1.  **Product Model - Missing `variants()` Relationship:**
    *   Added the `hasMany` relationship for `variants` to `app/Models/Product.php`,
        fixing "Call to undefined relationship [variants]" error on product edit page.

2.  **Attribute Queries - "Unknown column 'status'" Error:**
    *   Removed `where('status', 'active')` conditions when fetching Colors,
        Sizes, and Specifications in `ProductController@create` and
        `ProductController@edit`. This resolves SQL errors caused by the 'status'
        column not existing in the attribute tables as per initial migrations.

3.  **Attribute Controllers - `Request::validated()` Method Not Found:**
    *   Replaced `$request->validated()` with `$request->only([...])` in the
        `store` and `update` methods of `ColorController`, `SizeController`,
        and `SpecificationController` for secure mass assignment and to resolve
        the "Method Illuminate\Http\Request::validated does not exist" error.

4.  **Admin Order Details - Variant Display:**
    *   Ensured `OrderController@show` correctly eager loads full variant details
        for each order item (`orderItems.variant` with nested color, size,
        specification).
    *   Updated `resources/views/backend/order/show.blade.php` to display
        these specific variant attributes (SKU, Color, Size, Specification)
        for each item in an order.

These fixes address key functional blockers and improve the stability and correctness of the product variation and attribute management features.